### PR TITLE
Handle unnamed imports

### DIFF
--- a/integration/testproject/src/A.ts
+++ b/integration/testproject/src/A.ts
@@ -1,4 +1,5 @@
 import B, { foo } from "./B";
+import "./D";
 import { foo as foos } from "./C";
 
 console.log(foo, foos, B);

--- a/integration/testproject/src/D.ts
+++ b/integration/testproject/src/D.ts
@@ -1,0 +1,2 @@
+export const foo1 = "foo";
+export const foo2 = "foo";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-prune",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "lib/index.js",
   "author": "Nadeesha Cabral <n@nadeesha.me>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "typescript": "^3.5.2"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "minimist": "^1.2.0",
+    "true-myth": "^3.0.0",
     "ts-morph": "^2.3.0"
   },
   "files": [

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -5,6 +5,7 @@ import {
   SourceFileReferencingNodes,
   ts
 } from "ts-morph";
+import { isDefinitelyUsedImport } from "./util/isDefinitelyUsedImport";
 
 type OnResultType = (result: IAnalysedResult) => void;
 
@@ -51,12 +52,7 @@ function getExported(file: SourceFile) {
 
 const emitDefinitelyUsed = (file: SourceFile, onResult: OnResultType) => {
   file.getImportDeclarations().forEach(decl => {
-    const containsWildcardImport = decl
-      .getImportClause()
-      .getText()
-      .includes("*");
-
-    if (containsWildcardImport) {
+    if (isDefinitelyUsedImport(decl)) {
       onResult({
         file: decl.getModuleSpecifierSourceFile().getFilePath(),
         symbols: [],

--- a/src/util/isDefinitelyUsedImport.ts
+++ b/src/util/isDefinitelyUsedImport.ts
@@ -1,0 +1,16 @@
+import { ImportDeclaration } from "ts-morph";
+import { Maybe } from "true-myth";
+import identity from "lodash/fp/identity";
+
+const containsWildcardImport = (decl: ImportDeclaration) =>
+  Maybe.of(decl.getImportClause())
+    .mapOr("", clause => clause.getText())
+    .includes("*");
+
+const containsUnnamedImport = (decl: ImportDeclaration) =>
+  !decl.getImportClause();
+
+export const isDefinitelyUsedImport = (decl: ImportDeclaration) =>
+  [containsWildcardImport, containsUnnamedImport]
+    .map(fn => fn(decl))
+    .find(identity);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2608,6 +2608,11 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.14:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -3932,6 +3937,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+"true-myth@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/true-myth/-/true-myth-3.0.0.tgz#94e67a3bf270c2e09370dcab5a201b385750c92e"
+  integrity sha512-igEdH4YnEEpTsSZshp4MspGDooM4mOHWYUKyavmaUrhRd4oqWaUnbVgMLJc/Z/bz3s/UgYWAMHoTsG3FMTJWBg==
 
 ts-jest@^24.0.2:
   version "24.0.2"


### PR DESCRIPTION
This PR marks exports from all `import "./unnamedImport";` files as used.