### PR TITLE
Do not report false positives on "barrel export" files.

### DIFF
--- a/integration/testproject/src/barrel/E.ts
+++ b/integration/testproject/src/barrel/E.ts
@@ -1,0 +1,1 @@
+export type KualaOrLumpur = 'Kuala' | 'Lumpur';

--- a/integration/testproject/src/barrel/index.ts
+++ b/integration/testproject/src/barrel/index.ts
@@ -1,0 +1,1 @@
+export { KualaOrLumpur } from './E';

--- a/integration/testproject/src/importE.ts
+++ b/integration/testproject/src/importE.ts
@@ -1,0 +1,1 @@
+import { KualaOrLumpur } from './barrel';

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1,4 +1,5 @@
 import {
+  ExportDeclaration,
   ImportDeclaration,
   Project,
   SourceFile,
@@ -21,6 +22,10 @@ export interface IAnalysedResult {
   symbols: Array<string>;
 }
 
+function handleExportDeclaration(node: SourceFileReferencingNodes) {
+  return (node as ExportDeclaration).getNamedExports().map(n => n.getName());
+}
+
 function handleImportDeclaration(node: SourceFileReferencingNodes) {
   const referenced = [] as string[];
 
@@ -38,6 +43,7 @@ function handleImportDeclaration(node: SourceFileReferencingNodes) {
 }
 
 const nodeHandlers = {
+  [ts.SyntaxKind.ExportDeclaration.toString()]: handleExportDeclaration,
   [ts.SyntaxKind.ImportDeclaration.toString()]: handleImportDeclaration
 };
 


### PR DESCRIPTION
This should fix issue #40 .

However it is only the first step to handle more complex scenario when an export from "barrel export" is not used anywhere.