### PR TITLE
[FIX] Ignore files explicitly mentioned in tsconfig.json > files

### DIFF
--- a/integration/testproject/src/index.ts
+++ b/integration/testproject/src/index.ts
@@ -1,0 +1,1 @@
+export const libExport = "foo";

--- a/integration/testproject/tsconfig.json
+++ b/integration/testproject/tsconfig.json
@@ -11,7 +11,14 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6"]
+    "lib": [
+      "es6"
+    ]
   },
-  "include": ["./src/**/*"]
+  "include": [
+    "./src/**/*"
+  ],
+  "files": [
+    "./src/index.ts"
+  ]
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -9,10 +9,11 @@ import { present } from "./presenter";
 export const run = (argv = process.argv.slice(2), output = console.log) => {
   const tsConfigPath = minimist(argv).p || "tsconfig.json";
   const { project } = initialize(path.join(process.cwd(), tsConfigPath));
+  const entrypoints: string[] = require(path.join(process.cwd(), tsConfigPath))?.files?.map((file: string) => path.join(process.cwd(), file));
 
   const state = new State();
 
-  analyze(project, state.onResult);
+  analyze(project, state.onResult, entrypoints);
 
   const presented = present(state);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,16 @@
     "preserveConstEnums": true,
     "outDir": "lib",
     "sourceMap": true,
-    "lib": ["esnext"],
+    "lib": [
+      "esnext"
+    ],
     "esModuleInterop": true
   },
-  "include": ["src/index.ts"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "files": [
+    "src/index.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
Ignores files explicitly mentioned in the `files` property so that they can be exported without requiring an explicit ignore.

ex: Ignores the `src/index.ts` from a `tsconfig.json` as follows:

```
{
  "compilerOptions": {
    "target": "es5",
  },
  "files": [
    "src/index.ts"
  ],
  "exclude": [
    "node_modules",
    "**/*.spec.ts"
  ]
}
```