### PR TITLE
fix(core): Export type declarations for external usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "branches": [
       "master"
     ]
-  }
+  },
+  "types": "lib/index.d.ts"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 export { IConfigInterface } from "./configurator";
-export {run} from "./runner";
+export { run } from "./runner";
+export { ResultSymbol } from "./analyzer";
 
 import { getConfig } from "./configurator";
 import { run } from "./runner";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+export { IConfigInterface } from "./configurator";
+export {run} from "./runner";
 
 import { getConfig } from "./configurator";
 import { run } from "./runner";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "preserveConstEnums": true,
     "outDir": "lib",
     "sourceMap": true,
+    "declaration": true,
     "lib": [
       "esnext"
     ],


### PR DESCRIPTION
I'm wrapping ts-prune into an eslint plugin (https://github.com/wcandillon/eslint-plugin-ts-exports). And I could use the exported types.