### PR TITLE
SkipPattern: don't re-create new RegExp for each files

### DIFF
--- a/src/analyzer.test.ts
+++ b/src/analyzer.test.ts
@@ -97,7 +97,7 @@ describe("analyzer", () => {
 
   it("should skip source files matching a pattern", () => {
     // when bar.test.ts is exclude by the skip pattern, bar is unused
-    expect(getPotentiallyUnused(bar, ".test.ts")).toEqual({
+    expect(getPotentiallyUnused(bar, new RegExp(".test.ts"))).toEqual({
       file: "/project/bar.ts",
       symbols: [
         { line: 2, name: "bar", usedInModule: false },

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -17,7 +17,11 @@ export const run = (config: IConfigInterface, output = console.log) => {
 
   const state = new State();
 
-  analyze(project, state.onResult, entrypoints, config.skip);
+  let skipRegex;
+  if (config.skip) {
+    skipRegex = new RegExp(config.skip);
+  }
+  analyze(project, state.onResult, entrypoints, skipRegex);
 
   const presented = present(state);
 


### PR DESCRIPTION
This patch create the skip regex once on startup, it prevents the creation of a new regex for each files.