### PR TITLE
fix: Don't report incorrect line number on unused exports in `export * from`

### DIFF
--- a/integration/outfile.base
+++ b/integration/outfile.base
@@ -4,6 +4,8 @@ src/cities.ts:1 - sepehub
 src/cities.ts:2 - kuariob
 src/cities.ts:4 - femvacsah
 src/cities.ts:5 - sijelup
+src/export-from.ts:1 - foo1
+src/export-from.ts:1 - foo2
 src/internal-uses.ts:5 - usedInThisFile (used in module)
 src/internal-uses.ts:7 - thisOneIsUnused
 src/internal-uses.ts:9 - UsedInThisFile (used in module)

--- a/integration/testproject/src/export-from.ts
+++ b/integration/testproject/src/export-from.ts
@@ -1,0 +1,1 @@
+export * from "./D";

--- a/src/analyzer.test.ts
+++ b/src/analyzer.test.ts
@@ -17,9 +17,14 @@ export const unusedC = 'c';
 export type UnusedT = 'T';
 `;
 
+const starExportSrc = `
+export * from './foo';
+`;
+
 const starImportSrc = `
 import * as foo from './foo';
 import {UseFoo} from './use-foo';
+import {x,y,z,w,ABC} from './starExport';
 
 const x = foo.x;
 const {y} = foo;
@@ -55,6 +60,7 @@ describe("analyzer", () => {
   const star = project.createSourceFile("/project/star.ts", starImportSrc);
   const bar = project.createSourceFile("/project/bar.ts", barSrc);
   const testBar = project.createSourceFile("/project/bar.test.ts", testBarSrc);
+  const starExport = project.createSourceFile("/project/starExport.ts", starExportSrc);
 
   it("should track import wildcards", () => {
     // TODO(danvk): rename this to importSideEffects()
@@ -101,6 +107,17 @@ describe("analyzer", () => {
       file: "/project/bar.ts",
       symbols: [
         { line: 2, name: "bar", usedInModule: false },
+      ],
+      type: 0,
+    });
+  });
+
+  it("should use line number of 'export * from' rather than line number of original export", () => {
+    expect(getPotentiallyUnused(starExport)).toEqual({
+      file: "/project/starExport.ts",
+      symbols: [
+        { name: "unusedC", line: undefined, usedInModule:false },
+        { name: "UnusedT", line: undefined, usedInModule:false },
       ],
       type: 0,
     });

--- a/src/analyzer.test.ts
+++ b/src/analyzer.test.ts
@@ -116,8 +116,8 @@ describe("analyzer", () => {
     expect(getPotentiallyUnused(starExport)).toEqual({
       file: "/project/starExport.ts",
       symbols: [
-        { name: "unusedC", line: undefined, usedInModule:false },
-        { name: "UnusedT", line: undefined, usedInModule:false },
+        { name: "unusedC", line: 2, usedInModule:false },
+        { name: "UnusedT", line: 2, usedInModule:false },
       ],
       type: 0,
     });

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -155,12 +155,11 @@ const lineNumber = (symbol: Symbol) =>
   symbol.getDeclarations().map(decl => decl.getStartLineNumber()).reduce((currentMin, current) => Math.min(currentMin, current), Infinity)
 
 export const getExported = (file: SourceFile) =>
-  file.getExportSymbols()
-    .filter(symbol => !mustIgnore(symbol, file))
-    .map(symbol => ({
-      name: symbol.compilerSymbol.name,
-      line: lineNumber(symbol)
-    }));
+  file.getExportSymbols().filter(symbol => !mustIgnore(symbol, file))
+  .map(symbol => ({
+    name: symbol.compilerSymbol.name,
+    line: symbol.getDeclarations().every(decl => decl.getSourceFile() === file) ? lineNumber(symbol) : undefined,
+  }));
 
 /* Returns all the "import './y';" imports, which must be for side effects */
 export const importsForSideEffects = (file: SourceFile): IAnalysedResult[] =>


### PR DESCRIPTION
Attempt to address #141 – not a full solution, but at least the line number is now undefined instead of wrong. The issue occurs because `file.getExportSymbols()` returns symbols that are not in the file when `export * from` is present.

I am open to feedback on how to actually get the correct line number. I've left the tests in a failing state to demonstrate the desired result.