### PR TITLE
Allow use of "ignore" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ Configuration file example `.ts-prunerc`:
 }
 ```
 
+You can also put multiple ignore patterns.
+
+```json
+{
+  "ignore": [
+    "my-component-ignore-patterns?",
+    "my-other-component-ignore-patterns?"
+  ]
+}
+```
+
 ### FAQ
 
 #### How do I get the count of unused exports?
@@ -107,6 +118,17 @@ ts-prune --ignore 'src/ignore-this-path|src/also-ignore-this-path'
 
 ```sh
 ts-prune | grep -v src/ignore-this-path | grep -v src/also-ignore-this-path
+```
+
+##### 3. Use the `.ts-prunerc` configuration file `ignore` option:
+
+```json
+{
+  "ignore": [
+    "src/ignore-this-path",
+    "src/also-ignore-this-path"
+  ]
+}
 ```
 
 #### How do I ignore a specific identifier?

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -4,7 +4,7 @@ import pick from "lodash/fp/pick";
 
 export interface IConfigInterface {
   project?: string;
-  ignore?: string;
+  ignore?: string | string[];
   error?: string;
   skip?: string;
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,6 +8,14 @@ import { State } from "./state";
 import { present } from "./presenter";
 import { IConfigInterface } from "./configurator";
 
+const getIgnorePatterns = (configIgnore: IConfigInterface['ignore']): string[] => {
+  switch(typeof configIgnore) {
+    case 'undefined': return [];
+    case 'string': return [configIgnore];
+    case 'object': return configIgnore;
+  }
+};
+
 export const run = (config: IConfigInterface, output = console.log) => {
   const tsConfigPath = path.resolve(config.project);
   const { project } = initialize(tsConfigPath);
@@ -24,7 +32,11 @@ export const run = (config: IConfigInterface, output = console.log) => {
 
   const presented = present(state);
 
-  const filterIgnored = config.ignore !== undefined ? presented.filter(file => !file.match(config.ignore)) : presented;
+  const ignorePatterns = getIgnorePatterns(config.ignore);
+
+  const filterIgnored = ignorePatterns.length > 0
+    ? presented.filter(file => !ignorePatterns.some(pattern => file.match(pattern)))
+    : presented;
 
   filterIgnored.forEach(value => {
     output(value);


### PR DESCRIPTION
Use ts-prune in a big project with lot of ignored files can be hard since it gives a very long regex pattern.

I made some changes to allow `ignore` option to be a list of patterns. So `.ts-prunerc` file would be like that:
```json
{
  "ignore": [
    "my-component-ignore-patterns?",
    "my-other-component-ignore-patterns?"
  ]
}
```

There is no breaking changes since `string` type is still allowed like before :+1: 