### PR TITLE
Add JSON output and related config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ts-prune supports CLI and file configuration via [cosmiconfig](https://github.co
 - `-i, --ignore` - errors ignore RegExp pattern
 - `-e, --error` - return error code if unused exports are found
 - `-s, --skip` - skip these files when determining whether code is used. (For example, `.test.ts?` will stop ts-prune from considering an export in test file usages)
+- `-o, --output` - set output: "text" (default) or "json"
 
 CLI configuration options:
 

--- a/src/configurator.test.ts
+++ b/src/configurator.test.ts
@@ -3,7 +3,11 @@ describe("getConfig", () => {
   it("should return a sensible default config", () => {
     expect(getConfig()).toMatchInlineSnapshot(`
       Object {
+        "error": undefined,
+        "ignore": undefined,
+        "output": "text",
         "project": "tsconfig.json",
+        "skip": undefined,
       }
     `);
   });

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -3,10 +3,11 @@ import program from "commander";
 import pick from "lodash/fp/pick";
 
 export interface IConfigInterface {
-  project?: string;
+  project: string;
   ignore?: string;
   error?: string;
   skip?: string;
+  output: 'text' | 'json';
 }
 
 const defaultConfig: IConfigInterface = {
@@ -14,6 +15,7 @@ const defaultConfig: IConfigInterface = {
   ignore: undefined,
   error: undefined,
   skip: undefined,
+  output: 'text',
 }
 
 const onlyKnownConfigOptions = pick(Object.keys(defaultConfig));
@@ -26,11 +28,8 @@ export const getConfig = () => {
     .option('-i, --ignore [regexp]', 'Path ignore RegExp pattern')
     .option('-e, --error', 'Return error code if unused exports are found')
     .option('-s, --skip [regexp]', 'skip these files when determining whether code is used')
+    .option('-o, --output [output]', 'Set output: "text" or "json". Default: "text"', /text|json/)
     .parse(process.argv))
-
-  const defaultConfig = {
-    project: "tsconfig.json"
-  }
 
   const moduleName = 'ts-prune';
   const explorerSync = cosmiconfigSync(moduleName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 export { IConfigInterface } from "./configurator";
 export { run } from "./runner";
 export { ResultSymbol } from "./analyzer";
+export type { JSONOutput, JSONOutputItem } from './presenter';
 
 import { getConfig } from "./configurator";
 import { run } from "./runner";

--- a/src/present.test.ts
+++ b/src/present.test.ts
@@ -20,9 +20,9 @@ describe("present", () => {
     ].forEach((result) => state.onResult(result));
 
     it("should produce a presentable output", () => {
-      expect(JSON.stringify(present(state))).toMatchInlineSnapshot(
-        `"[\\"foo.ts:0 - foo\\",\\"bar.ts:0 - bar\\"]"`
-      );
+      expect(
+        JSON.stringify(present(state, { output: "text" }))
+      ).toMatchInlineSnapshot(`"[\\"foo.ts:0 - foo\\",\\"bar.ts:0 - bar\\"]"`);
     });
   });
 
@@ -43,7 +43,9 @@ describe("present", () => {
     ].forEach((result) => state.onResult(result));
 
     it("should produce an empty output", () => {
-      expect(JSON.stringify(present(state))).toBe(JSON.stringify([]));
+      expect(JSON.stringify(present(state, { output: "text" }))).toBe(
+        JSON.stringify([])
+      );
     });
   });
 
@@ -64,8 +66,48 @@ describe("present", () => {
     ].forEach((result) => state.onResult(result));
 
     it("should produce a presentable output", () => {
-      expect(JSON.stringify(present(state))).toMatchInlineSnapshot(
+      expect(
+        JSON.stringify(present(state, { output: "text" }))
+      ).toMatchInlineSnapshot(
         `"[\\"foo.ts:0 - foo (used in module)\\",\\"bar.ts:0 - bar\\"]"`
+      );
+    });
+  });
+
+  describe("when output config is set to json, and given state with unused exports", () => {
+    const state = new State();
+
+    [
+      {
+        type: AnalysisResultTypeEnum.POTENTIALLY_UNUSED,
+        symbols: [{ name: "foo", line: 0, usedInModule: false }],
+        file: "foo.ts",
+      },
+      {
+        type: AnalysisResultTypeEnum.POTENTIALLY_UNUSED,
+        symbols: [{ name: "bar", line: 0, usedInModule: false }],
+        file: "bar.ts",
+      },
+    ].forEach((result) => state.onResult(result));
+
+    it("should produce a json output", () => {
+      expect(present(state, { output: "json" })).toEqual(
+        [
+          JSON.stringify([
+            {
+              filePath: "foo.ts",
+              line: 0,
+              name: "foo",
+              usedInModule: false,
+            },
+            {
+              filePath: "bar.ts",
+              line: 0,
+              name: "bar",
+              usedInModule: false,
+            },
+          ]),
+        ]
       );
     });
   });

--- a/src/presenter.ts
+++ b/src/presenter.ts
@@ -2,7 +2,9 @@ import chalk from 'chalk';
 import { State } from "./state";
 import { IConfigInterface } from './configurator';
 
-type JSONOutput = {
+export type JSONOutput = JSONOutputItem[];
+
+export type JSONOutputItem = {
   filePath: string;
   line?: number;
   name: string;
@@ -11,12 +13,12 @@ type JSONOutput = {
 
 const USED_IN_MODULE = ' (used in module)';
 
-const presentText = (jsonResults: JSONOutput[]): string[] => jsonResults.map(({ filePath, line, name, usedInModule }) =>
+const presentText = (jsonResults: JSONOutput): string[] => jsonResults.map(({ filePath, line, name, usedInModule }) =>
   `${chalk.green(filePath)}:${chalk.yellow(line)} - ${chalk.cyan(name)}`
   + (usedInModule ? `${chalk.grey(USED_IN_MODULE)}` : '')
 );
 
-const presentJSON = (jsonResults: JSONOutput[]): string[] => [JSON.stringify(jsonResults)];
+const presentJSON = (jsonResults: JSONOutput): string[] => [JSON.stringify(jsonResults)];
 
 export const present = (state: State, { output, ignore }: Pick<IConfigInterface, 'output' | 'ignore'>): string[] => {
   const jsonResults = state.definitelyUnused()
@@ -27,7 +29,7 @@ export const present = (state: State, { output, ignore }: Pick<IConfigInterface,
         return [];
       }
 
-      return symbols.map(({ name, line, usedInModule }): JSONOutput => ({
+      return symbols.map(({ name, line, usedInModule }): JSONOutputItem => ({
         filePath,
         line,
         name,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,12 +22,10 @@ export const run = (config: IConfigInterface, output = console.log) => {
 
   analyze(project, state.onResult, entrypoints, config.skip);
 
-  const presented = present(state);
+  const presented = present(state, config);
 
-  const filterIgnored = config.ignore !== undefined ? presented.filter(file => !file.match(config.ignore)) : presented;
-
-  filterIgnored.forEach(value => {
+  presented.forEach(value => {
     output(value);
   });
-  return filterIgnored.length;
+  return presented.length;
 };


### PR DESCRIPTION
ts-prune may be used in a script context. So its output may be used for external process.

For this kind of use I added a JSON output, and a "output" option to define it.

There is some refactoring in `presenter.ts` and `runner.ts`.

Default use doesn't change, and tests work like before. Note that some tests were already broken on master.
