### PR TITLE
Add -u option to filter out "(used in module)" results

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ts-prune supports CLI and file configuration via [cosmiconfig](https://github.co
 - `-i, --ignore` - errors ignore RegExp pattern
 - `-e, --error` - return error code if unused exports are found
 - `-s, --skip` - skip these files when determining whether code is used. (For example, `.test.ts?` will stop ts-prune from considering an export in test file usages)
-- `-u, --unusedInModule` - do not display "(used in module)" unused exports
+- `-u, --unusedInModule` - skip files that are used in module (marked as `used in module`)
 
 CLI configuration options:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ts-prune supports CLI and file configuration via [cosmiconfig](https://github.co
 - `-i, --ignore` - errors ignore RegExp pattern
 - `-e, --error` - return error code if unused exports are found
 - `-s, --skip` - skip these files when determining whether code is used. (For example, `.test.ts?` will stop ts-prune from considering an export in test file usages)
+- `-u, --unusedInModule` - do not display "(used in module)" unused exports
 
 CLI configuration options:
 

--- a/integration/outfile_unusedInModules.base
+++ b/integration/outfile_unusedInModules.base
@@ -1,0 +1,15 @@
+src/B.ts:9 - UnusedFooType
+src/C.ts:9 - default
+src/cities.ts:1 - sepehub
+src/cities.ts:2 - kuariob
+src/cities.ts:4 - femvacsah
+src/cities.ts:5 - sijelup
+src/export-from.ts:undefined - foo1
+src/export-from.ts:undefined - foo2
+src/internal-uses.ts:7 - thisOneIsUnused
+src/internal-uses.ts:11 - Unused
+src/internal-uses.ts:17 - UnusedProps
+src/dynamic/fail.ts:1 - foo
+src/dynamic/fail.ts:3 - bar
+src/skipPattern/foo.ts:3 - foo
+src/wildcard/foo.ts:5 - vUnused

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -34,6 +34,24 @@ else
   EXIT_CODE=0
 fi
 
+step "Run ts-prune with --unusedInModule option"
+ts-prune --skip "skip.me" --unusedInModule | tee outfile_unusedInModules
+
+step "Diff between outputs"
+DIFF=$(diff outfile_unusedInModules ../outfile_unusedInModules.base)
+EXIT_CODE=2
+if [ "$DIFF" != "" ] 
+then
+  echo "The output was not the same as the base"
+  echo "---"
+  diff outfile_unusedInModules ../outfile_unusedInModules.base
+  echo "---"
+  EXIT_CODE=1
+else
+  echo "Everything seems to be match! 🎉"
+  EXIT_CODE=0
+fi
+
 step "Test exit code with no error flag"
 if ! ts-prune > /dev/null; then
   echo "ts-prune with no error flag returned error"
@@ -67,6 +85,7 @@ fi
 step "Cleanup"
 rm ../../package-lock.json # remnants of the npm link
 rm outfile # generated outfile
+rm outfile_unusedInModules # generated outfile
 
 echo "🏁"
 exit $EXIT_CODE

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -28,7 +28,7 @@ export const getConfig = () => {
     .option('-i, --ignore [regexp]', 'Path ignore RegExp pattern')
     .option('-e, --error', 'Return error code if unused exports are found')
     .option('-s, --skip [regexp]', 'skip these files when determining whether code is used')
-    .option('-u, --unusedInModule', 'only count unused exports not used in module')
+    .option('-u, --unusedInModule', 'Skip files that are used in module (marked as `used in module`)')
     .parse(process.argv))
 
   const defaultConfig = {

--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -7,6 +7,7 @@ export interface IConfigInterface {
   ignore?: string;
   error?: string;
   skip?: string;
+  unusedInModule?: string;
 }
 
 const defaultConfig: IConfigInterface = {
@@ -14,6 +15,7 @@ const defaultConfig: IConfigInterface = {
   ignore: undefined,
   error: undefined,
   skip: undefined,
+  unusedInModule: undefined,
 }
 
 const onlyKnownConfigOptions = pick(Object.keys(defaultConfig));
@@ -26,6 +28,7 @@ export const getConfig = () => {
     .option('-i, --ignore [regexp]', 'Path ignore RegExp pattern')
     .option('-e, --error', 'Return error code if unused exports are found')
     .option('-s, --skip [regexp]', 'skip these files when determining whether code is used')
+    .option('-u, --unusedInModule', 'only count unused exports not used in module')
     .parse(process.argv))
 
   const defaultConfig = {

--- a/src/presenter.ts
+++ b/src/presenter.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { State } from "./state";
 import { ResultSymbol } from "./analyzer";
 
-const USED_IN_MODULE = ' (used in module)';
+export const USED_IN_MODULE = ' (used in module)';
 
 const formatOutput = (file: string, result: ResultSymbol) => {
   const {name, line, usedInModule} = result;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 import { analyze } from "./analyzer";
 import { initialize } from "./initializer";
 import { State } from "./state";
-import { present } from "./presenter";
+import { present, USED_IN_MODULE } from "./presenter";
 import { IConfigInterface } from "./configurator";
 
 export const run = (config: IConfigInterface, output = console.log) => {
@@ -24,7 +24,8 @@ export const run = (config: IConfigInterface, output = console.log) => {
 
   const presented = present(state);
 
-  const filterIgnored = config.ignore !== undefined ? presented.filter(file => !file.match(config.ignore)) : presented;
+  const filterUsedInModule = config.unusedInModule !== undefined ? presented.filter(file => !file.includes(USED_IN_MODULE)) : presented;
+  const filterIgnored = config.ignore !== undefined ? filterUsedInModule.filter(file => !file.match(config.ignore)) : filterUsedInModule;
 
   filterIgnored.forEach(value => {
     output(value);


### PR DESCRIPTION
Closes #198 

It allows users to display only code that can be removed (as opposed to "used in module" results where you only have to remove the `export` keyword.

The name of this option is `-u` (or `--unusedInModule`). Feel free to suggest a better name!