### PR TITLE
feat: add custom path flag for the config file

### DIFF
--- a/src/configurator.ts
+++ b/src/configurator.ts
@@ -1,12 +1,14 @@
 import { cosmiconfigSync } from "cosmiconfig";
 import program from "commander";
 import pick from "lodash/fp/pick";
+import chalk from "chalk";
 
 export interface IConfigInterface {
   project?: string;
   ignore?: string;
   error?: string;
   skip?: string;
+  config?: string;
 }
 
 const defaultConfig: IConfigInterface = {
@@ -14,33 +16,56 @@ const defaultConfig: IConfigInterface = {
   ignore: undefined,
   error: undefined,
   skip: undefined,
-}
+  config: undefined,
+};
 
 const onlyKnownConfigOptions = pick(Object.keys(defaultConfig));
 
-
 export const getConfig = () => {
-  const cliConfig = onlyKnownConfigOptions(program
-    .allowUnknownOption() // required for tests passing in unknown options (ex: https://github.com/nadeesha/ts-prune/runs/1125728070)
-    .option('-p, --project [project]', 'TS project configuration file (tsconfig.json)', 'tsconfig.json')
-    .option('-i, --ignore [regexp]', 'Path ignore RegExp pattern')
-    .option('-e, --error', 'Return error code if unused exports are found')
-    .option('-s, --skip [regexp]', 'skip these files when determining whether code is used')
-    .parse(process.argv))
+  const cliConfig = onlyKnownConfigOptions(
+    program
+      .allowUnknownOption() // required for tests passing in unknown options (ex: https://github.com/nadeesha/ts-prune/runs/1125728070)
+      .option(
+        "-p, --project [project]",
+        "TS project configuration file (tsconfig.json)",
+        "tsconfig.json"
+      )
+      .option("-i, --ignore [regexp]", "Path ignore RegExp pattern")
+      .option("-e, --error", "Return error code if unused exports are found")
+      .option(
+        "-s, --skip [regexp]",
+        "skip these files when determining whether code is used"
+      )
+      .option(
+        "-c, --config [path]",
+        "Path to config file (default: .ts-prunerc.json)"
+      )
+      .parse(process.argv)
+  );
 
   const defaultConfig = {
-    project: "tsconfig.json"
+    project: "tsconfig.json",
+  };
+
+  const moduleName = "ts-prune";
+  const explorerSync = cosmiconfigSync(moduleName);
+  let fileConfig;
+  try {
+    fileConfig = cliConfig.config
+      ? explorerSync.load(cliConfig.config).config
+      : explorerSync.search()?.config;
+  } catch (error) {
+    console.log(chalk.red(`Error loading config file\n${error.message}`));
+    process.exit(1);
   }
 
-  const moduleName = 'ts-prune';
-  const explorerSync = cosmiconfigSync(moduleName);
-  const fileConfig = explorerSync.search()?.config;
+  delete cliConfig.config;
 
   const config: IConfigInterface = {
     ...defaultConfig,
     ...fileConfig,
-    ...cliConfig
+    ...cliConfig,
   };
 
   return config;
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,13 +841,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/chalk@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
-  integrity sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==
-  dependencies:
-    chalk "*"
-
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz"
@@ -1516,11 +1509,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-chalk@*:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
-  integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
 
 chalk@4.1.2:
   version "4.1.2"


### PR DESCRIPTION
Now you can specify a custom path for the config file. 
`npx ts-prune --config path/to/my/custom/config.json`