### PR TITLE
docs: revive dead badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://img.shields.io/github/workflow/status/nadeesha/ts-prune/Run%20CI%20Pipeline) ![npm](https://img.shields.io/npm/dm/ts-prune) ![GitHub issues](https://img.shields.io/github/issues-raw/nadeesha/ts-prune)
+[![Test](https://github.com/nadeesha/ts-prune/actions/workflows/test.yml/badge.svg)](https://github.com/nadeesha/ts-prune/actions/workflows/test.yml) ![npm](https://img.shields.io/npm/dm/ts-prune) ![GitHub issues](https://img.shields.io/github/issues-raw/nadeesha/ts-prune)
 
 # 🚨 ts-prune is going into maintanence mode
 


### PR DESCRIPTION
Replaced shields.io badge with GitHub badge.

Ref: https://github.com/badges/shields/issues/8671